### PR TITLE
Update mytab.js

### DIFF
--- a/mytab/mytab.js
+++ b/mytab/mytab.js
@@ -218,7 +218,10 @@ function updatetime(){
 			}
 		}
 		if(game.settings.get('mytab', 'pausetime') == ""){
-		document.getElementById("countdown").innerHTML = "";
+			let countdown = document.getElementById("countdown")
+			if(countdown) {
+				countdown.innerHTML = "";
+			}
 		}
 };
 


### PR DESCRIPTION
During startup one gets an error like the following as the countdown has not yet been displayed, this PR avoids that by not trying to set innerHtml until countdown exists:
```
foundry.js:2499 TypeError: Cannot set property 'innerHTML' of null
    at updatetime (mytab.js:221)
    at Pauserender (mytab.js:359)
    at mytab.js:426
    at Function._call (foundry.js:2496)
```